### PR TITLE
Add static page for competitor analysis

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Text-to-Video AI Platforms Analysis</title>
+    <style>
+        body { font-family: Arial, sans-serif; line-height: 1.6; margin: 20px; max-width: 800px; }
+        h1, h2, h3 { color: #2c3e50; }
+        table { border-collapse: collapse; width: 100%; margin-bottom: 1em; }
+        th, td { border: 1px solid #ccc; padding: 8px; text-align: left; }
+        th { background-color: #f5f5f5; }
+    </style>
+</head>
+<body>
+<h1>Text-to-Video AI Platforms: Competitive Landscape and Pricing Analysis</h1>
+<p>Thanks for the context. I’ll investigate how other companies offer AI video generation services—especially for social media posts—including pricing models (like per-second or credit-based systems), feature sets, and API use. I’ll also analyze typical costs for using third-party APIs and suggest a pricing model for your SaaS product, ContentCraft AI, that balances competitiveness with profitability.</p>
+<p>I’ll let you know once I have the findings ready.</p>
+
+<h2>Competitive Overview</h2>
+<p>Several AI-driven text-to-video platforms have emerged to help users create short videos for social media and marketing with minimal effort. Key competitors include <strong>Synthesia</strong>, <strong>Runway ML</strong>, <strong>Pika Labs</strong>, <strong>Lumen5</strong>, <strong>Pictory</strong>, and others (e.g. InVideo, Fliki, HeyGen). Each platform has a unique focus:</p>
+<ul>
+<li><strong>Synthesia</strong> – Specializes in <strong>AI avatar</strong> videos. Users type a script and choose a photorealistic avatar that speaks it in multiple languages. It’s popular for corporate training, marketing, and e-learning content. Synthesia targets enterprise use, offering an easy studio for internal video creation without cameras or actors. It provides an API for integration and supports 140+ languages with realistic voice synthesis. <em>Pricing model:</em> subscription plans that include a fixed number of video minutes per month.</li>
+<li><strong>Runway ML</strong> – Known for cutting-edge <strong>generative AI video</strong> tools, Runway enables text-, image-, or video-prompted video generation and advanced AI video editing (e.g. style transfer, background removal). It caters to creatives and developers, supporting high resolutions up to 4K. Runway offers both subscriptions and pay-as-you-go credits. <em>Pricing model:</em> a low monthly fee includes some credits, and additional usage is billed via credits (purchased per second of generated video).</li>
+<li><strong>Pika Labs</strong> – A newer entrant focusing on <strong>text-to-video diffusion models</strong>. Pika generates short animated videos from text or images, with various creative effects (e.g. “cinematic” or cartoon styles). Initially launched via a Discord bot, it now offers a web interface and API. Pika’s strength is in AI-generated visuals and animations for engaging social content. <em>Pricing model:</em> credit-based subscriptions (with daily free credits, tiered paid plans, and an unlimited plan). Users spend credits per second of video generated (roughly 5 credits per second in its high-quality mode).</li>
+<li><strong>Lumen5</strong> – An <strong>AI-assisted video maker</strong> that turns scripts or blog posts into videos by automatically matching text with stock images/video clips. Aimed at marketing teams and content creators, it provides a drag-and-drop editor with templates and branding tools. Lumen5’s AI suggests layouts and visuals but does not generate original footage – it relies on large stock media libraries. <em>Pricing model:</em> tiered subscriptions with unlimited video creation (plans differ by features like resolution and asset libraries). There is no per-video charge; users can create as many videos as needed within their plan.</li>
+<li><strong>Pictory</strong> – Focuses on <strong>automated video creation from text content</strong>. Pictory can take long-form content (like blog articles, webinars, or transcripts) and automatically summarize and convert them into short videos with captions. It uses stock footage and <strong>text-to-speech</strong> for voiceovers. Notably, it integrates third-party AI voices (ElevenLabs) for more natural narration. <em>Pricing model:</em> subscription plans that grant a certain number of video minutes per month. Unused minutes do not roll over, but within the limit users can produce multiple videos. An API is offered for automation use cases.</li>
+<li><strong>InVideo</strong> – (Comparable to Lumen5) A template-driven online video editor with some AI features (like automated text-to-speech and a library of stock media). It’s suited for marketers creating promo videos, social content, etc. <em>Pricing model:</em> subscription plans (e.g. $25/mo for “Plus” with unlimited video exports). InVideo does not charge per video or per minute – all videos are included, with higher plans offering more stock assets and higher resolutions.</li>
+</ul>
+<p>Other players like <strong>HeyGen</strong> and <strong>Colossyan</strong> (avatar video creators similar to Synthesia), <strong>Fliki</strong> (text-to-video with AI voiceovers), or <strong>Elai.io</strong> also compete in this space. Each platform balances ease-of-use, AI capabilities, and pricing structure to target different user needs – from casual creators to enterprise teams.</p>
+
+<h2>Pricing Model Comparison Table</h2>
+<table>
+<thead>
+<tr><th>Platform</th><th>Pricing Model</th><th>Example Plan & Allowance</th><th>Pay-Per-Use Credits</th></tr>
+</thead>
+<tbody>
+<tr><td><strong>Synthesia</strong></td><td>Subscription (minutes/month). Enterprise custom plans.</td><td><em>Starter:</em> ~$30/mo for <strong>10 minutes</strong> video per month (1080p output). <em>Creator:</em> ~$90/mo for 30 min/mo. Higher tiers increase minutes (Enterprise = unlimited).</td><td>No self-serve pay-as-you-go. Extra usage requires upgrading plans. API access included in Creator+ plans (with videos counting against minutes).</td></tr>
+<tr><td><strong>Runway ML</strong></td><td>Subscription + credit system (“pay as you go”).</td><td><em>Standard:</em> $12/mo per user (billed yearly) including <strong>625 credits</strong> monthly (~52 seconds of highest-gen video). <em>Pro:</em> $28/mo per user with 2250 credits (≈187 sec). <em>Unlimited:</em> $76/mo with same credits plus unlimited “relaxed” generations.</td><td><strong>Yes – Credits</strong> cost $0.01 each. Different models consume credits per second (e.g. 5 credits/sec for Gen-4 Turbo, i.e. $0.05/sec). You can buy extra credits on demand, making Runway a true usage-based platform beyond the monthly allotment.</td></tr>
+<tr><td><strong>Pika Labs</strong></td><td>Credit-based subscription (with free tier and unlimited option).</td><td><em>Basic:</em> Free (30 credits/day). <em>Standard:</em> $10/mo for <strong>700</strong> monthly credits + daily 30 credits (no watermark, 720p). <em>Unlimited:</em> $35/mo for unlimited “Chill” generations + 2000 credits/mo (+30 daily). <em>Pro:</em> $70/mo <strong>unlimited</strong> fast generations (no credit limit).</td><td><strong>Yes – Credits</strong> determine video length. ~<strong>5 credits per second</strong> for high-speed generation (i.e. 1 sec video uses 5 credits). Credits do not roll over. The Unlimited/Pro plans remove per-video costs, useful for power users.</td></tr>
+<tr><td><strong>Lumen5</strong></td><td>Tiered Subscription (unlimited videos within plan).</td><td><em>Basic:</em> $19/mo (720p, Lumen5 watermark removed). <em>Starter:</em> $59/mo (1080p HD, 50M stock library). <em>Professional:</em> $149/mo (more advanced features, 500M stock). Enterprise plans are custom.</td><td><strong>No per-video credits.</strong> All plans allow unlimited video exports. Pricing scales with features (resolution, assets, branding). Cost <strong>per video</strong> effectively drops if you create many videos; e.g. 10 videos/month on Starter would average ~$5.9 each, whereas 1 video would effectively cost $59.</td></tr>
+<tr><td><strong>Pictory</strong></td><td>Subscription (minutes of output per month).</td><td><em>Starter:</em> $19/mo for <strong>200 minutes</strong> of video/month. <em>Professional:</em> $39/mo for 600 minutes/month. <em>Teams:</em> $99/mo for 1800 minutes. All in 1080p with no watermarks; unused minutes don’t carry over.</td><td><strong>No pay-per-use</strong> credits; you must upgrade for more minutes. (However, Pictory’s generous limits – e.g. 200 min for $19 – mean cost per minute can be as low as ~$0.10 if fully utilized). Pictory also includes some premium stock assets and a quota of <strong>ElevenLabs</strong> AI voice minutes for more realistic TTS.</td></tr>
+<tr><td><strong>InVideo</strong></td><td>Subscription (unlimited exports).</td><td><em>Plus:</em> $25/mo – unlimited video exports (HD), 80 stock media items per month. <em>Max:</em> $60/mo – unlimited exports, more assets and team collaboration. Free tier produces watermarked videos.</td><td><strong>No credit system.</strong> Once subscribed, any number of videos can be created. The value comes from access to premium templates, stock library, and features rather than paying per video.</td></tr>
+</tbody>
+</table>
+<p><strong>Note:</strong> Other AI video platforms follow similar models. <strong>HeyGen</strong> (another avatar video service) for instance has a Creator plan ~$30/mo for 5 minutes and a Team plan ~$90/mo for 20 minutes, and also offers an API starting ~$99/mo for credits. <strong>Elai.io</strong> offers video minutes at around <$2 per minute on higher plans. These benchmarks indicate that charging on the order of a few dollars per output minute is common for AI-generated video services – with higher prices justified by more advanced AI capabilities (like ultra-realistic avatars or fully generated visuals) and cheaper plans for tools that use simpler automation (like stock footage montage).</p>
+
+<h2>Technology Stack and API Usage</h2>
+<p>The platforms differ in whether they use proprietary AI models or third-party services under the hood:</p>
+<ul>
+<li><strong>Synthesia:</strong> Uses largely <strong>proprietary AI models</strong> developed in-house for its avatar video generation. The company has a research team that built its own models for lifelike face animation and voice synthesis. It trains these models on consented footage of actors to create each avatar. Synthesia can even train custom “digital twin” avatars for clients using its proprietary tech. While most of the core tech is proprietary, Synthesia acknowledges using “third-party foundational model technology opportunistically”.</li>
+<li><strong>Runway ML:</strong> Built heavily on <strong>proprietary generative models</strong>, though with roots in open-source. Runway collaborated in the development of Stable Diffusion for images and then created its own video models (Gen-1, Gen-2, and beyond). The latest models (Gen-3, Gen-4) are Runway’s internal R&D and are served via its cloud API. Runway’s platform integrates various AI capabilities (image generation, video generation, video editing). It does not rely on third-party APIs for generation; instead it provides its models through the Runway API.</li>
+<li><strong>Pika Labs:</strong> Pika’s text-to-video is based on <strong>diffusion models</strong> (akin to Stable Diffusion but for video). The co-founders (AI researchers) likely fine-tuned or developed a custom video diffusion model. Pika does not appear to call external APIs for generation; instead, users run generations on Pika’s site or via Pika’s API.</li>
+<li><strong>Lumen5:</strong> Lumen5’s “AI” features revolve around automation rather than generative neural networks. It likely uses some NLP for analyzing input text. Lumen5 does not generate visuals via AI; it selects from a stock media library. It may incorporate third-party services for text processing or voiceovers.</li>
+<li><strong>Pictory:</strong> Combines several tools, some likely powered by third-party AI. Notably, Pictory’s inclusion of <strong>ElevenLabs</strong> voices for ultra-realistic speech indicates reliance on an external API for that feature. Pictory likely uses a mix of third-party AI services such as speech-to-text, text summarization, and text-to-speech along with its own software logic.</li>
+<li><strong>InVideo:</strong> Similar to Lumen5, InVideo is primarily a traditional video editor in a browser with some automation. It probably leverages third-party TTS engines and simple AI recommendation systems, rather than proprietary generative models.</li>
+</ul>
+<p><strong>Summary of tech stacks:</strong> The high-end platforms (Runway, Synthesia, Pika) have proprietary AI models at their core, while platforms like Pictory and Lumen5 act more as integrators/orchestrators using a combination of in-house software and external AI services.</p>
+
+<h2>Cost Estimation and Margin Suggestions</h2>
+<p>If <strong>ContentCraft AI</strong> opts to leverage third-party AI APIs for video generation rather than training its own model, it’s crucial to estimate those costs and incorporate a healthy margin. Below we break down typical costs for third-party video generation and related AI services, then discuss pricing strategies.</p>
+<p><strong>1. Video Generation API Costs (per second):</strong></p>
+<ul>
+<li><strong>Runway ML API:</strong> Runway charges <strong>$0.01 per credit</strong>, with ~5 credits required for 1 second of standard generative video. This equates to <strong>$0.05 per second</strong> or <strong>$3.00 per minute</strong> of video generation.</li>
+<li><strong>Pika Labs API:</strong> Pika’s pricing suggests roughly <strong>$0.03–$0.05 per second</strong> of video. This would mean $1.80–$3.00 per minute of video in raw API cost.</li>
+<li><strong>OpenAI APIs:</strong> Using GPT-4, DALL·E, or Whisper adds only minor costs per video (typically under $0.50 total).</li>
+<li><strong>Other APIs:</strong> Premium voiceovers from providers like ElevenLabs might add ~$0.20–$0.30 per video minute.</li>
+</ul>
+<p><strong>2. Total Third-Party Cost Per Minute:</strong> Combining these, a 1 minute video could cost around <strong>$3–$4 per minute</strong> in variable costs when using top-tier external APIs.</p>
+<p><strong>3. Profit Margin and Markup:</strong> To achieve a healthy gross margin (around 50% or higher), ContentCraft AI could charge roughly <strong>$0.10 per second</strong> (~$6 per minute) to the end user.</p>
+
+<h2>Final Recommendations</h2>
+<p>The following outlines a credit-based pricing model suggestion for ContentCraft AI:</p>
+<ol>
+<li><strong>Use a Credit System:</strong> 1 credit equals 1 second of generated video at standard quality.</li>
+<li><strong>Offer Tiered Plans with Credit Bundles:</strong> For example, Starter at $29/mo for 300 credits (5 minutes), and Professional at $79/mo for 1000 credits (≈16 min).</li>
+<li><strong>Pay-as-You-Go Option:</strong> Allow purchasing credits individually for occasional use.</li>
+<li><strong>Free Trial/Tier:</strong> Provide a small free allowance, e.g., 20 seconds of video free for new users.</li>
+<li><strong>Competitive Positioning:</strong> Communicate that AI-generated visuals are more resource-intensive than stock-based tools, justifying the higher price.</li>
+<li><strong>Profit Margin and Monitoring:</strong> Aim for 50–60% gross margin initially and negotiate volume discounts with API providers as usage grows.</li>
+</ol>
+<p>This structure pegs ContentCraft’s pricing firmly against competitive benchmarks while ensuring the company can cover API costs and earn a profit.</p>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create HTML document describing the AI video generation landscape

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843b24b939c832e88964e86f54c271d